### PR TITLE
fix docker-compose.yaml warning

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   inference:
     container_name: inference-basic-eth-pred


### PR DESCRIPTION
"version is obsolete"

Docker has made this line obsolete, no need to mention docker compose version.

https://github.com/mailcow/mailcow-dockerized/issues/5797#issuecomment-2010649543

https://forums.docker.com/t/docker-compose-yml-version-is-obsolete/141313

https://news.ycombinator.com/item?id=40196989