### PR TITLE
Update init.config

### DIFF
--- a/init.config
+++ b/init.config
@@ -16,6 +16,9 @@ fi
 json_content=$(cat ./config.json)
 stringified_json=$(echo "$json_content" | jq -c .)
 
+# Ensure the worker-data directory exists
+mkdir -p ./worker-data
+
 mnemonic=$(jq -r '.wallet.addressRestoreMnemonic' config.json)
 if [ -n "$mnemonic" ]; then
     echo "ALLORA_OFFCHAIN_NODE_CONFIG_JSON='$stringified_json'" > ./worker-data/env_file
@@ -24,9 +27,6 @@ if [ -n "$mnemonic" ]; then
     echo "wallet mnemonic already provided by you, loading config.json . Please proceed to run docker compose"
     exit 1
 fi
-
-# Ensure the worker-data directory exists
-mkdir -p ./worker-data
 
 if [ ! -f ./worker-data/env_file ]; then
     echo "ENV_LOADED=false" > ./worker-data/env_file


### PR DESCRIPTION
`init.config` script should create `worker-data` directory first, then it should write any data to that folder.

Not doing so results in:
```
./init.config: line 21: ./worker-data/env_file: No such file or directory
```
This PR moves `mkdir` logic before anything else.